### PR TITLE
Update theme.xml

### DIFF
--- a/res/xml/theme.xml
+++ b/res/xml/theme.xml
@@ -48,7 +48,7 @@
         <com.extra.settings.preferences.CustomSeekBarPreference
             android:key="sysui_rounded_content_padding"
             android:title="@string/content_padding"
-            android:max="10"
+            android:max="18"
             settings:min="0"
             settings:units=""
             android:persistent="false"


### PR DESCRIPTION
Increase sysui_rounded_content_padding max value to add more padding for devices with huge rounded corners (e.g. Pocophone F1, Mi 8)